### PR TITLE
feat: Shape up docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:18-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR shape up docker image by using node 18-slim as base image instead of node 18.