### PR TITLE
Add link to book resource and adding more resources

### DIFF
--- a/docs/docs/resources.md
+++ b/docs/docs/resources.md
@@ -15,11 +15,17 @@ title: Resources
 - [Data Science for Business](https://www.amazon.com/Data-Science-Business-Data-Analytic-Thinking-ebook/dp/B00E6EQ3X4/) - Foster Provost & Tom Fawcett
 - [Practical Statistics for Data Scientists](https://www.amazon.com/Practical-Statistics-Data-Scientists-Essential/dp/149207294X/) - Peter Gedeck & Peter Bruce & Andrew Bruce
 - [97 Things Every Data Engineer Should Know](https://www.amazon.com/Things-Every-Data-Engineer-Should/dp/1492062413/) - Tobias Macey
+- [Designing Cloud Data Platforms](https://www.amazon.com/Designing-Cloud-Platforms-Danil-Zburivsky/dp/1617296449/) - Danil Zburivsky & Lynda Partner
+- [Data Pipelines Pocket Reference](https://www.amazon.com/Data-Pipelines-Pocket-Reference-Processing/dp/1492087831/) - James Densmore
 
 ### Software engineering
 
 - [Python Crash Course](https://www.amazon.com/Python-Crash-Course-2nd-Edition/dp/1593279280/) - Eric Matthes
 - [The Pragmatic Programmer](https://www.amazon.com/Pragmatic-Programmer-Journeyman-Master/dp/020161622X/) - Andrew Hunt & David Thomas
+- [Refactoring](https://www.amazon.com/gp/product/0134757599/) - Martin Fowler
+- [Clean Code](https://www.amazon.com/Clean-Code-Handbook-Software-Craftsmanship/dp/0132350882/) - Robert C.Martin
+- [Software Engineering at Google](https://www.amazon.com/Software-Engineering-Google-Lessons-Programming/dp/1492082791/) - Titus Winters
+- [Docs for Developers](https://www.amazon.com/dp/1484272161/) - Jared Bhatti, Zachary Sarah Corleissen, Jen Lambourne, David Nunez, Heidi Waterhouse
 
 ### Platform
 
@@ -31,6 +37,7 @@ title: Resources
 - [Radical Candor](https://www.amazon.com/Radical-Candor-What-Want-Saying-ebook/dp/B01LW1LESC/) - Kim Scott
 - [Data Teams](https://www.amazon.com/Data-Teams-Management-Successful-Data-Focused/dp/1484262271/) - Jesse Anderson
 - [Practical DataOps](https://www.amazon.com/Practical-DataOps-Delivering-Agile-Science/dp/1484251032/) - Harvinder Atwal
+- [The Phoenix Project](https://www.amazon.com/Phoenix-Project-DevOps-Helping-Business-ebook/dp/B078Y98RG8/) - Gene Kim, Kevin Behr, George Spafford
 
 ## บทความ / เว็บไซต์
 
@@ -40,3 +47,8 @@ title: Resources
 - <https://www.secoda.co/glossary>
 - <https://www.gentlydownthe.stream/>
 - <https://b-greve.gitbook.io/beginners-guide-to-clean-data/>
+- <https://www.startdataengineering.com>
+
+## พอดแคสต์
+
+- <https://www.dataengineeringpodcast.com>

--- a/docs/docs/resources.md
+++ b/docs/docs/resources.md
@@ -8,29 +8,29 @@ title: Resources
 
 ### พื้นฐาน (เหมาะสำหรับผู้เริ่มต้น)
 
-- Fundamentals of Data Engineering - Joe Reis & Matt Housley
-- Seven Databases in Seven Weeks - Luc Perkins & Eric Redmond & Jim Wilson
-- Designing Data-Intensive Applications - Martin Kleppmann
-- The Data Warehouse Toolkit - Ralph Kimball & Margy Ross
-- Data Science for Business - Foster Provost & Tom Fawcett
-- Practical Statistics for Data Scientists - Peter Gedeck & Peter Bruce & Andrew Bruce
-- 97 Things Every Data Engineer Should Know - Tobias Macey
+- [Fundamentals of Data Engineering](https://www.amazon.com/Fundamentals-Data-Engineering-Robust-Systems/dp/1098108302) - Joe Reis & Matt Housley
+- [Seven Databases in Seven Weeks](https://www.amazon.com/Seven-Databases-Weeks-Modern-Movement/dp/1680502530/) - Luc Perkins & Eric Redmond & Jim Wilson
+- [Designing Data-Intensive Applications](https://www.amazon.com/Designing-Data-Intensive-Applications-Reliable-Maintainable/dp/1449373321/) - Martin Kleppmann
+- [The Data Warehouse Toolkit](https://www.amazon.com/Data-Warehouse-Toolkit-Definitive-Dimensional/dp/1118530802/) - Ralph Kimball & Margy Ross
+- [Data Science for Business](https://www.amazon.com/Data-Science-Business-Data-Analytic-Thinking-ebook/dp/B00E6EQ3X4/) - Foster Provost & Tom Fawcett
+- [Practical Statistics for Data Scientists](https://www.amazon.com/Practical-Statistics-Data-Scientists-Essential/dp/149207294X/) - Peter Gedeck & Peter Bruce & Andrew Bruce
+- [97 Things Every Data Engineer Should Know](https://www.amazon.com/Things-Every-Data-Engineer-Should/dp/1492062413/) - Tobias Macey
 
 ### Software engineering
 
-- Python Crash Course - Eric Matthes
-- The Pragmatic Programmer - Andrew Hunt & David Thomas
+- [Python Crash Course](https://www.amazon.com/Python-Crash-Course-2nd-Edition/dp/1593279280/) - Eric Matthes
+- [The Pragmatic Programmer](https://www.amazon.com/Pragmatic-Programmer-Journeyman-Master/dp/020161622X/) - Andrew Hunt & David Thomas
 
 ### Platform
 
-- Terraform: Up & Running - Yevgeniy Brikman
+- [Terraform: Up & Running](https://www.amazon.com/Terraform-Running-Writing-Infrastructure-Code/dp/1098116747/) - Yevgeniy Brikman
 
 ### Management
 
-- Team Topologies - Matthew Skelton & Manuel Pais
-- Radical Candor - Kim Scott
-- Data Teams - Jesse Anderson
-- Practical DataOps - Harvinder Atwal
+- [Team Topologies](https://www.amazon.com/Team-Topologies-Organizing-Business-Technology/dp/1942788819/) - Matthew Skelton & Manuel Pais
+- [Radical Candor](https://www.amazon.com/Radical-Candor-What-Want-Saying-ebook/dp/B01LW1LESC/) - Kim Scott
+- [Data Teams](https://www.amazon.com/Data-Teams-Management-Successful-Data-Focused/dp/1484262271/) - Jesse Anderson
+- [Practical DataOps](https://www.amazon.com/Practical-DataOps-Delivering-Agile-Science/dp/1484251032/) - Harvinder Atwal
 
 ## บทความ / เว็บไซต์
 


### PR DESCRIPTION
Change proposed in this pull request
* Add link to Amazon for existing book resources
* Add `Designing Cloud Data Platforms` & `Data Pipelines Pocket Reference` in Fundamental book resources
* Add `Refactoring`, `Clean Code`, `Software Engineering at Google`, `Docs for Developers` to Software Engineering book resources
* Add `The Phoenix Project` to Management book resources
* Add `https://www.startdataengineering.com` to website resources
* Add `https://www.dataengineeringpodcast.com` and initial Podcast resources section